### PR TITLE
Enable http support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -83,6 +83,7 @@ args=(
 	--enable-protocol=file
 	--enable-protocol=pipe
 	--enable-protocol=tee
+	--enable-protocol=http
 
 	# Libraries
 	--enable-libmp3lame


### PR DESCRIPTION
This will enable remote files to be probed (without having to download them first).